### PR TITLE
Enable supporting SavedModel format for TensorFlow and XLA backends

### DIFF
--- a/configs/backend/tensorflow.yaml
+++ b/configs/backend/tensorflow.yaml
@@ -2,6 +2,7 @@ _target_: backends.tensorflow.TensorflowBackend
 name: tensorflow
 version: ${tensorflow_version:}
 use_xla: false
+use_saved_model_format: false
 eager_mode: true
 experimental_compiler: false
 num_threads: null

--- a/configs/backend/xla.yaml
+++ b/configs/backend/xla.yaml
@@ -2,6 +2,7 @@ _target_: backends.tensorflow.TensorflowBackend
 name: tensorflow_xla
 version: ${tensorflow_version:}
 use_xla: true
+use_saved_model_format: false
 eager_mode: false
 experimental_compiler: false
 num_threads: null

--- a/src/backends/tensorflow.py
+++ b/src/backends/tensorflow.py
@@ -100,12 +100,14 @@ class TensorflowBackend(Backend[TensorflowConfig]):
         super().__init__(model)
         self.model = model
         self.model_info = None  # Only used when working with SavedModel
-        self.local_model_path = local_model_path  # Local
+        self.local_model_path = local_model_path  # Local model path if using pre-exported SavedModel file
 
         LOGGER.info(f"Allocated TensorFlow Backend for model: {model}")
 
     @classmethod
     def allocate(cls, config: BenchmarkConfig):
+        # Check if we are using a local SavedModel file
+        # => (format <model_topology@model_local_page => bert-base-case@/path/to/savedmodel)
         if config.backend.use_saved_model_format and "@" in config.model:
             model_name, model_path = config.model.split("@")
             LOGGER.info(f"Local SavedModel format detected: model={model_name}, path={model_path}")

--- a/src/backends/tensorflow.py
+++ b/src/backends/tensorflow.py
@@ -16,13 +16,15 @@ import contextlib
 from dataclasses import dataclass
 from logging import getLogger
 from pathlib import Path
+from shutil import rmtree
 from typing import Optional, Tuple, Callable, List, Set
 
 import numpy as np
 import tensorflow as tf
-from tensorflow.python.keras import Input, Model
+from tensorflow.keras.models import Model
+from tensorflow.python.keras import Input
 from tqdm import trange
-from transformers import PreTrainedTokenizer, TFAutoModel, TFPreTrainedModel, TensorType
+from transformers import PreTrainedTokenizer, TFAutoModel, TFBertModel, TFPreTrainedModel, TensorType
 
 from backends import Backend, BackendConfig
 from benchmark import Benchmark
@@ -43,21 +45,20 @@ def get_tf_device(device: str) -> str:
         return tf.DeviceSpec(device_type="CPU")
 
 
-def as_saved_model(tokenizer: PreTrainedTokenizer, model: TFPreTrainedModel, inputs: List, saved_model_path: Path, flag: str = "tune") -> Callable:
-    encodings = tokenizer(inputs, is_split_into_words=True)
+def as_saved_model(tokenizer: PreTrainedTokenizer, model: TFPreTrainedModel, inputs: List, saved_model_path: Path, flag: str = "tune") -> Path:
+    encodings = tokenizer(inputs, is_split_into_words=True, return_tensors="tf")
 
     # Generate symbolic trace
-    tf_inputs = {name: Input((None, ), batch_size=None, dtype=tf.int64, name=name) for name, value in encodings.items()}
+    tf_inputs = {name: Input((None, ), batch_size=None, dtype=tf.int32, name=name) for name, value in encodings.items()}
     tf_outputs = model(tf_inputs)
-    tf_model = Model(inputs=tf_inputs, outputs=tf_outputs)
+    tf_model = tf.keras.models.Model(inputs=tf_inputs, outputs={"output": tf_outputs[0]})
 
     # Saved SavedModel
     tf.saved_model.save(tf_model, saved_model_path.as_posix())
-    model_f = tf.saved_model.load(saved_model_path.as_posix()).signatures["serving_default"]
 
     # Generate a flag file indicating this folder was generated from the tune framework
     saved_model_path.joinpath(flag).touch()
-    return model_f
+    return saved_model_path
 
 
 @contextlib.contextmanager
@@ -77,6 +78,7 @@ class TensorflowConfig(BackendConfig):
     use_saved_model_format: bool = False
     eager_mode: bool = True
     experimental_compiler: Optional[bool] = None
+    local_model_path: Optional[str] = None
 
     @staticmethod
     def version() -> str:
@@ -84,22 +86,37 @@ class TensorflowConfig(BackendConfig):
 
     @staticmethod
     def supported_keys() -> Set[str]:
-        return BackendConfig.supported_keys().union({"use_xla", "eager_mode", "experimental_compiler", "use_saved_model_format"})
+        return BackendConfig.supported_keys().union({
+            "use_xla",
+            "eager_mode",
+            "experimental_compiler",
+            "use_saved_model_format",
+            "local_model_path"
+        })
 
 
 class TensorflowBackend(Backend[TensorflowConfig]):
     NAME = BACKEND_NAME
     SAVED_MODEL_PATH = "saved_model"
 
-    def __init__(self, model: str):
+    def __init__(self, model: str, local_model_path: str = None):
         super().__init__(model)
         self.model = model
+        self.model_info = None  # Only used when working with SavedModel
+        self.local_model_path = local_model_path  # Local
 
         LOGGER.info(f"Allocated TensorFlow Backend for model: {model}")
 
     @classmethod
     def allocate(cls, config: BenchmarkConfig):
-        backend = TensorflowBackend(config.model)
+        if config.backend.use_saved_model_format and "@" in config.model:
+            model_name, model_path = config.model.split("@")
+            LOGGER.info(f"Local SavedModel format detected: model={model_name}, path={model_path}")
+
+            backend = TensorflowBackend(model_name, model_path)
+        else:
+            backend = TensorflowBackend(config.model)
+
         backend.configure(config.backend)
 
         return backend
@@ -108,7 +125,8 @@ class TensorflowBackend(Backend[TensorflowConfig]):
         saved_model_path = Path(TensorflowBackend.SAVED_MODEL_PATH)
         if saved_model_path.exists() and saved_model_path.joinpath("tune"):
             LOGGER.debug(f"Cleaning SavedModel folder at {saved_model_path}")
-            saved_model_path.rmdir()
+            rmtree(saved_model_path)
+            # saved_model_path.rmdir()
 
     def configure(self, config: TensorflowConfig):
         super().configure(config)
@@ -144,23 +162,38 @@ class TensorflowBackend(Backend[TensorflowConfig]):
                 f"))"
             )
 
-        # If we need to save the model as SavedModel format
+        # If we need to use the model as SavedModel format
         if config.use_saved_model_format:
-            # Let's look if the SavedModel can be found locally
-            saved_model_path = Path(self.model)
-            if saved_model_path.exists() and saved_model_path.joinpath("saved_model.pb").exists():
-                LOGGER.info(f"Found local SavedModel model at {saved_model_path.absolute()}")
-                self.model = tf.saved_model.load(saved_model_path.as_posix())
-            else:
-                LOGGER.info(f"Converting {self.model} to SavedModel format")
-                model = TFAutoModel.from_pretrained(self.model)
-                self.model = as_saved_model(
-                    tokenizer=self.tokenizer,
-                    model=model,
-                    inputs=self._get_dummy_inputs(1, 1),
-                    saved_model_path=Path(TensorflowBackend.SAVED_MODEL_PATH),
-                    flag="tune"
-                )
+
+            # Local model support
+            if self.local_model_path is None:
+                LOGGER.info(f"Converting model: {self.model} to SavedModel format")
+                with options({
+                    "constant_folding": True,
+                    "shape_optimization": True,
+                    "disable_model_pruning": False,
+                    "arithmetic_optimization": True,
+                    "function_optimization": True
+                }):
+                    with tf.device("CPU"):
+                        model = TFAutoModel.from_pretrained(self.model)
+                        self.local_model_path = as_saved_model(
+                            tokenizer=self.tokenizer,
+                            model=model,
+                            inputs=self._get_dummy_inputs(
+                                1, model.config.max_position_embeddings - self.tokenizer.num_special_tokens_to_add()
+                            ),
+                            saved_model_path=Path(TensorflowBackend.SAVED_MODEL_PATH),
+                            flag="tune"
+                        )
+
+                    LOGGER.debug(f"Converted SavedModel stored at {self.local_model_path}")
+
+            # Load the model
+            saved_model_path = Path(self.local_model_path)
+            LOGGER.info(f"Loading SavedModel from {saved_model_path}")
+            self.model_info = tf.saved_model.load(saved_model_path.as_posix())
+            self.model = self.model_info.signatures["serving_default"]
         else:
             # Postponing model allocation to tune intra/inter ops before executing any other TF related code.
             self.model = TFAutoModel.from_pretrained(self.model)
@@ -184,16 +217,19 @@ class TensorflowBackend(Backend[TensorflowConfig]):
             inputs = self.tokenizer(
                 dummy_inputs,
                 is_split_into_words=True,
-                return_tensors=TensorType.NUMPY,
+                return_tensors=TensorType.TENSORFLOW,
             )
 
             # Move tf.constants to GPU ... https://github.com/tensorflow/tensorflow/issues/42242#issuecomment-675590057
             inputs = {name: tf.identity(t) for name, t in inputs.items()}
 
+            # SavedModel concrete function needs unwrapped arguments ...
+            model_f = lambda x: self.model(**x) if config.backend.use_saved_model_format else self.model
+
             # Warmup
             outputs = []
             for _ in trange(config.warmup_runs, desc="Warming up"):
-                output = self.model(inputs)
+                output = model_f(inputs)
                 outputs.append(output.last_hidden_state.numpy())
 
             # Let's not run the benchmark for the reference backend,
@@ -204,7 +240,7 @@ class TensorflowBackend(Backend[TensorflowConfig]):
                 benchmark_duration_ns = config.benchmark_duration * SEC_TO_NS_SCALE
                 while sum(benchmark.latencies) < benchmark_duration_ns:
                     with benchmark.track():
-                        self.model(inputs)
+                        model_f(inputs)
 
                 benchmark.finalize(benchmark_duration_ns)
 
@@ -213,7 +249,11 @@ class TensorflowBackend(Backend[TensorflowConfig]):
     def _run_xla(self, config: BenchmarkConfig, is_reference: bool) -> Tuple[Benchmark, np.ndarray]:
         @tf.function(experimental_compile=config.backend.experimental_compiler)
         def xla_model(inputs):
-            return self.model(inputs)
+            # SavedModel concrete function needs unwrapped arguments ...
+            if config.backend.use_saved_model_format:
+                return self.model(**inputs)
+            else:
+                return self.model(inputs)
 
         LOGGER.info("Running TensorFlow XLA benchmark")
         benchmark = Benchmark()

--- a/src/backends/tensorflow.py
+++ b/src/backends/tensorflow.py
@@ -30,8 +30,11 @@ from benchmark import Benchmark
 from config import BenchmarkConfig
 from utils import SEC_TO_NS_SCALE
 
-
 BACKEND_NAME = "tensorflow"
+
+SAVED_MODEL_PATH = "saved_model"
+SAVED_MODEL_TUNE_FLAG = "tune"
+
 LOGGER = getLogger("tensorflow")
 
 
@@ -44,7 +47,7 @@ def get_tf_device(device: str) -> str:
         return tf.DeviceSpec(device_type="CPU")
 
 
-def as_saved_model(tokenizer: PreTrainedTokenizer, model: TFPreTrainedModel, inputs: List, saved_model_path: Path, flag: str = "tune") -> Path:
+def as_saved_model(tokenizer: PreTrainedTokenizer, model: TFPreTrainedModel, inputs: List, saved_model_path: Path, flag: str = SAVED_MODEL_TUNE_FLAG) -> Path:
     encodings = tokenizer(inputs, is_split_into_words=True, return_tensors="tf")
 
     # Generate symbolic trace
@@ -94,7 +97,6 @@ class TensorflowConfig(BackendConfig):
 
 class TensorflowBackend(Backend[TensorflowConfig]):
     NAME = BACKEND_NAME
-    SAVED_MODEL_PATH = "saved_model"
 
     def __init__(self, model: str, local_model_path: str = None):
         super().__init__(model)
@@ -121,8 +123,8 @@ class TensorflowBackend(Backend[TensorflowConfig]):
         return backend
 
     def clean(self, config: 'BenchmarkConfig'):
-        saved_model_path = Path(TensorflowBackend.SAVED_MODEL_PATH)
-        if saved_model_path.exists() and saved_model_path.joinpath("tune"):
+        saved_model_path = Path(SAVED_MODEL_PATH)
+        if saved_model_path.exists() and saved_model_path.joinpath(SAVED_MODEL_TUNE_FLAG):
             LOGGER.debug(f"Cleaning SavedModel folder at {saved_model_path}")
             rmtree(saved_model_path)
             # saved_model_path.rmdir()
@@ -182,8 +184,8 @@ class TensorflowBackend(Backend[TensorflowConfig]):
                             inputs=self._get_dummy_inputs(
                                 1, model.config.max_position_embeddings - self.tokenizer.num_special_tokens_to_add()
                             ),
-                            saved_model_path=Path(TensorflowBackend.SAVED_MODEL_PATH),
-                            flag="tune"
+                            saved_model_path=Path(SAVED_MODEL_PATH),
+                            flag=SAVED_MODEL_TUNE_FLAG
                         )
 
                     LOGGER.debug(f"Converted SavedModel stored at {self.local_model_path}")

--- a/src/backends/tensorflow.py
+++ b/src/backends/tensorflow.py
@@ -21,10 +21,9 @@ from typing import Optional, Tuple, Callable, List, Set
 
 import numpy as np
 import tensorflow as tf
-from tensorflow.keras.models import Model
 from tensorflow.python.keras import Input
 from tqdm import trange
-from transformers import PreTrainedTokenizer, TFAutoModel, TFBertModel, TFPreTrainedModel, TensorType
+from transformers import PreTrainedTokenizer, TFAutoModel, TFPreTrainedModel, TensorType
 
 from backends import Backend, BackendConfig
 from benchmark import Benchmark
@@ -78,7 +77,6 @@ class TensorflowConfig(BackendConfig):
     use_saved_model_format: bool = False
     eager_mode: bool = True
     experimental_compiler: Optional[bool] = None
-    local_model_path: Optional[str] = None
 
     @staticmethod
     def version() -> str:
@@ -91,7 +89,6 @@ class TensorflowConfig(BackendConfig):
             "eager_mode",
             "experimental_compiler",
             "use_saved_model_format",
-            "local_model_path"
         })
 
 


### PR DESCRIPTION
- Introduce `backend.use_saved_model_format=<true|false>` for `tensorflow` and `xla` backend.
- Introduce the possibility to load pre-exported SavedModel model through `model=<model_id>@<model_path>` for instance: `bert-large-uncased@/path/to/local/savedmodel`
- Enable on the fly conversion from Keras model to SavedModel
- Enable XLA with SavedModel