### PR TITLE
Always set threading config for PyTorch

### DIFF
--- a/src/backends/pytorch.py
+++ b/src/backends/pytorch.py
@@ -120,16 +120,16 @@ class PyTorchBackend(Backend[PyTorchConfig]):
         LOGGER.info("\t+ Turning eval mode on Module (model.eval())")
 
         if config.num_threads is not None:
-            if torch.get_num_threads() != config.num_threads:
-                torch.set_num_threads(config.num_threads)
+            # if torch.get_num_threads() != config.num_threads:
+            torch.set_num_threads(config.num_threads)
 
             LOGGER.info(f"\t+ Number of threads (torch.set_num_threads({config.num_threads}))")
 
         if config.num_interops_threads is not None:
             # TODO: Setting this value multiple times between PyTorch & TorchScript runs raise a C error
 
-            if torch.get_num_interop_threads() != config.num_interops_threads:
-                torch.set_num_interop_threads(config.num_interops_threads)
+            # if torch.get_num_interop_threads() != config.num_interops_threads:
+            torch.set_num_interop_threads(config.num_interops_threads)
 
             LOGGER.info(
                 f"\t+ Number of interop threads (torch.set_num_interop_threads({config.num_interops_threads}))"


### PR DESCRIPTION
Fix some strange performance regression thanks to git bisect.

**Reference (7c4e28583e9c6ad888175ad44a915f50c07a17ac):**
```
                                   Latency & Throughput for each framework (latencies given in ms)
┏━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━┓
┃   Backend   ┃  Malloc  ┃ OpenMP  ┃ Huge Pages ┃ Batch ┃ Sequence ┃ Avg. Latency ┃ Std. Latency ┃ Throughput ┃ Cores ┃ Instance ID ┃
┡━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━┩
│   pytorch   │ tcmalloc │ default │  madvise   │   1   │    20    │    11.32     │     0.52     │   88.32    │  40   │      0      │
│   pytorch   │ tcmalloc │ default │  madvise   │   1   │    20    │     11.3     │     0.52     │   88.53    │  40   │      1      │
│ torchscript │ tcmalloc │ default │  madvise   │   1   │    20    │     8.24     │     0.06     │   121.35   │  40   │      0      │
│ torchscript │ tcmalloc │ default │  madvise   │   1   │    20    │     8.22     │     0.04     │   121.68   │  40   │      1      │
```

**Current main (tune, HEAD~1):**
```shell
                                 Latency & Throughput for each framework (latencies given in ms)
┏━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━┓
┃   Backend   ┃ Malloc ┃ OpenMP ┃ Huge Pages ┃ Batch ┃ Sequence ┃ Avg. Latency ┃ Std. Latency ┃ Throughput ┃ Cores ┃ Instance ID ┃
┡━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━┩
│   pytorch   │  std   │  iomp  │  madvise   │   1   │    20    │    12.75     │     0.68     │   78.42    │  40   │      0      │
│   pytorch   │  std   │  iomp  │  madvise   │   1   │    20    │    12.58     │     0.68     │   79.47    │  40   │      1      │
│ torchscript │  std   │  iomp  │  madvise   │   1   │    20    │     9.41     │     0.07     │   106.3    │  40   │      0      │
│ torchscript │  std   │  iomp  │  madvise   │   1   │    20    │     9.37     │     0.05     │   106.72   │  40   │      1      │
└─────────────┴────────┴────────┴────────────┴───────┴──────────┴──────────────┴──────────────┴────────────┴───────┴─────────────┘
```

**This commit (tune)**
```shell
                                 Latency & Throughput for each framework (latencies given in ms)
┏━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━┓
┃   Backend   ┃ Malloc ┃ OpenMP ┃ Huge Pages ┃ Batch ┃ Sequence ┃ Avg. Latency ┃ Std. Latency ┃ Throughput ┃ Cores ┃ Instance ID ┃
┡━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━┩
│   pytorch   │  std   │  iomp  │  madvise   │   1   │    20    │    11.58     │     0.09     │   86.37    │  40   │      0      │
│   pytorch   │  std   │  iomp  │  madvise   │   1   │    20    │    11.48     │     0.08     │   87.12    │  40   │      1      │
│ torchscript │  std   │  iomp  │  madvise   │   1   │    20    │     8.42     │     0.07     │   118.77   │  40   │      0      │
│ torchscript │  std   │  iomp  │  madvise   │   1   │    20    │     8.36     │     0.05     │   119.62   │  40   │      1      │
└─────────────┴────────┴────────┴────────────┴───────┴──────────┴──────────────┴──────────────┴────────────┴───────┴─────────────┘
```
