### PR TITLE
Fix utils import path

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -32,7 +32,7 @@ from argparse import RawTextHelpFormatter
 import logging
 import psutil
 
-from utils import CPUinfo
+from src.utils import CPUinfo
 
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
Running the following command currently gives the error:

`python launcher.py --enable_tcmalloc --enable_iomp --ninstances=2 -- src/main.py --info config model=bert-base-cased batch_size=16 sequence_length=512`
```
 Traceback (most recent call last):
  File "/home/ubuntu/tune/launcher.py", line 35, in <module>
    from utils import CPUinfo
ModuleNotFoundError: No module named 'utils'
```

This PR corrects the import path, env: python3.9